### PR TITLE
A setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@ django-bootstrap-toolkit
 
 django-bootstrap-toolkit is a Django application for easily incorporating the Bootstrap framework in Django projects.
 
+Install
+-------
+
+Just call `pip install -e git+https://github.com/dyve/django-bootstrap.git#egg=django-bootstrap` and add `bootstrap` to your `INSTALLED_APPS`.
+
+Alternatively, you can add `-e git+https://github.com/dyve/django-bootstrap.git#egg=django-bootstrap` to your requirements.txt.
+
+If you want to hack django-bootstrap itself, clone this repo and call `pip install -e .`.
+
 About
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+import os
+from setuptools import setup
+
+root_dir = os.path.dirname(__file__)
+if not root_dir:
+    root_dir = '.'
+long_desc = open(root_dir + '/README.md').read()
+
+
+setup(
+    name='django-bootstrap-toolkit',
+    version='0.1',
+    url='https://github.com/dyve/django-bootstrap-toolkit',
+    author='Dylan Verheul',
+    author_email='dylan@dyve.net',
+    license='Apache License 2.0',
+    install_requires=['Django'],
+    packages=['bootstrap', 'bootstrap.templatetags'],
+    package_data={'bootstrap': ['templates/bootstrap/*.html']},
+    description='Bootstrap support for Django projects',
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Utilities",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        ],
+    long_description=long_desc,
+)

--- a/test_project/bootstrap
+++ b/test_project/bootstrap
@@ -1,1 +1,0 @@
-../bootstrap/


### PR DESCRIPTION
I also deleted the symlink test_project/bootstrap. Now, to run the
test_project, you have to django-bootstrap installed.  I have added a
few lines in the readme to explain how to install in the general case,
and how to install for development.
