### PR TITLE
non_field_errors support added

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/form.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/form.html
@@ -1,6 +1,8 @@
 {% load bootstrap_toolkit %}
 
-{{ form.non_field_errors }}
+{% if form.non_field_errors %}
+    {% include "bootstrap_toolkit/non_field_errors.html" %}
+{% endif %}
 
 {% for field in form.hidden_fields %}
     {{ field }}

--- a/bootstrap_toolkit/templates/bootstrap_toolkit/non_field_errors.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/non_field_errors.html
@@ -1,0 +1,8 @@
+<div data-alert="alert" class="alert alert-error fade in">
+    <a href="#" data-dismiss="alert" class="close">&times;</a>
+    <ol>
+        {% for error in form.non_field_errors %}
+            <li><strong>{{ error }}</strong></li>
+        {% endfor %}
+    </ol>
+</div>


### PR DESCRIPTION
I've added non_field_errors support to templates (alert, alert-error, fade in effect and close button).

Used <ol> for general error list (like the numbers), but feel free to change to <ul> if need.
