### PR TITLE
Support single bootstrap.js file

### DIFF
--- a/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
+++ b/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
@@ -13,6 +13,10 @@ BOOTSTRAP_JS_BASE_URL = getattr(settings, 'BOOTSTRAP_JS_BASE_URL',
     BOOTSTRAP_BASE_URL + 'js/'
 )
 
+BOOTSTRAP_JS_URL = getattr(settings, 'BOOTSTRAP_JS_URL',
+    None
+)
+
 BOOTSTRAP_CSS_BASE_URL = getattr(settings, 'BOOTSTRAP_CSS_BASE_URL',
     BOOTSTRAP_BASE_URL + 'css/'
 )
@@ -42,13 +46,17 @@ def bootstrap_javascript_url(name):
     """
     URL to Bootstrap javascript file
     """
+    if BOOTSTRAP_JS_URL:
+        return BOOTSTRAP_JS_URL
     return BOOTSTRAP_JS_BASE_URL + 'bootstrap-' + name + '.js'
+
 
 @register.simple_tag
 def bootstrap_javascript_tag(name):
     """
     HTML tag to insert bootstrap_toolkit javascript file
     """
+
     return u'<script src="%s"></script>' % bootstrap_javascript_url(name)
 
 @register.filter

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -149,3 +149,10 @@ LOGGING = {
         },
     }
 }
+
+BOOTSTRAP_BASE_URL      = 'http://twitter.github.com/bootstrap/assets/'
+BOOTSTRAP_CSS_BASE_URL  = BOOTSTRAP_BASE_URL + 'css/'
+BOOTSTRAP_CSS_URL       = BOOTSTRAP_CSS_BASE_URL + 'bootstrap.css'
+BOOTSTRAP_JS_BASE_URL   = BOOTSTRAP_BASE_URL + 'js/'
+# Enable for single bootstrap.js file
+#BOOTSTRAP_JS_URL        = BOOTSTRAP_JS_BASE_URL + 'bootstrap.js'


### PR DESCRIPTION
Modified bootstrap_toolkit.py to support users with a single bootstrap.js file while preserving existing behaviour.
Added default settings to settings.py.
