### PR TITLE
Don't blow up if an empty context variable is passed to `as_bootstrap`

### DIFF
--- a/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
+++ b/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
@@ -1,4 +1,5 @@
-from django.forms import BaseForm, Field
+from django.forms import BaseForm
+from django.forms.forms import BoundField
 from django.forms.widgets import TextInput, CheckboxInput, CheckboxSelectMultiple, RadioSelect
 from django.template import Context
 from django.template.loader import get_template
@@ -72,13 +73,16 @@ def as_bootstrap(form_or_field, layout='vertical'):
                 'layout': layout,
             })
         )
-    else:
+    elif isinstance(form_or_field, BoundField):
         return get_template("bootstrap_toolkit/field.html").render(
             Context({
                 'field': form_or_field,
                 'layout': layout,
             })
         )
+    else:
+        # Display the default
+        return settings.TEMPLATE_STRING_IF_INVALID
 
 @register.filter
 def is_disabled(field):


### PR DESCRIPTION
If the template code basses in an empty context variable, the
`bootstrap_input_type` templatetag throws a ValueError that's difficult
to debug.  This patch changes the template tag to just show an empty
string (or whatever is defined in TEMPLATE_STRING_IF_INVALID), so the
debugging can be done at the rendering level.
