### PR TITLE
Added option for .controls-row class

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_horizontal.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_horizontal.html
@@ -1,6 +1,6 @@
 <div class="control-group{% if field.errors %} error{% endif %}{% if field.field.required %} required{% endif %}">
     <label class="control-label"{% if field.auto_id and not input_type == "multicheckbox" and not input_type == "radioset" %} for="{{ field.auto_id }}"{% endif %}>{{ field.label }}</label>
-    <div class="controls">
+    <div class="controls{% if float %} controls-row{% endif %}">
         {% if input_type == "checkbox" %}
             {% include "bootstrap_toolkit/field_checkbox.html" %}
         {% else %}

--- a/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
+++ b/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
@@ -61,16 +61,22 @@ def bootstrap_javascript_tag(name):
     return u'<script src="%s"></script>' % bootstrap_javascript_url(name)
 
 @register.filter
-def as_bootstrap(form_or_field, layout='vertical'):
+def as_bootstrap(form_or_field, layout='vertical,false'):
     """
     Render a field or a form according to Bootstrap guidelines
     """
-    layout = str(layout).lower()
+    params = split(layout, ",")
+    layout = str(params[0]).lower()
+
+    if len(params) > 1:
+        float = str(params[1]).lower() == "float"
+
     if isinstance(form_or_field, BaseForm):
         return get_template("bootstrap_toolkit/form.html").render(
             Context({
                 'form': form_or_field,
                 'layout': layout,
+                'float': float,
             })
         )
     elif isinstance(form_or_field, BoundField):
@@ -78,6 +84,7 @@ def as_bootstrap(form_or_field, layout='vertical'):
             Context({
                 'field': form_or_field,
                 'layout': layout,
+                'float': float,
             })
         )
     else:


### PR DESCRIPTION
I added the possibility to add the .controls-row class to the control divs like described here:

http://twitter.github.com/bootstrap/base-css.html#forms

"For multiple grid inputs per line, use the .controls-row modifier class for proper spacing. It floats the inputs to collapse white-space, sets the proper margins, and the clears the float."

You can use it like this: {{ form|as_bootstrap:"horizontal,float" }}

It is just a proposal :)
Alex
