### PR TITLE
Added automatic format generation for the date picker.

### DIFF
--- a/bootstrap_toolkit/widgets.py
+++ b/bootstrap_toolkit/widgets.py
@@ -18,6 +18,12 @@ def add_to_css_class(classes, new_class):
         classes = u" ".join(classes)
     return classes
 
+def convert_date_format(format):
+    format = format.replace('%m', 'mm')
+    format = format.replace('%d', 'dd')
+    format = format.replace('%Y', 'yyyy')
+    format = format.replace('%y', 'yy')
+    return format
 
 class BootstrapDateInput(forms.DateInput):
 
@@ -26,15 +32,9 @@ class BootstrapDateInput(forms.DateInput):
         'prepend': None,
     }
 
-    def __init__(self, *args, **kwargs):
-        if 'popup_date_format' in kwargs:
-            date_format = kwargs.pop('popup_date_format')
-            if not 'attrs' in kwargs or kwargs['attrs'] is None:
-                kwargs['attrs'] = {}
-            if date_format:
-                kwargs['attrs']['data-date-format'] = date_format
-
-        super(BootstrapDateInput, self).__init__(*args, **kwargs)
+    def __init__(self, attrs=None, format=None):
+        super(BootstrapDateInput, self).__init__(attrs, format)
+        self.attrs['data-date-format'] = convert_date_format(str(self.format))
 
     class Media:
         js = (


### PR DESCRIPTION
The date format of the calendar popup is now automatically generated from the widget's date format. This simplifies using custom date formats for those of us who put the month first.

The BootstrapDateInput is now a subclass of DateInput. 
