### PR TITLE
BUGFIX: missing prepend / append for TextInput widget

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_default.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_default.html
@@ -1,30 +1,13 @@
-{% comment %}
-    Spaceless is required here to make sure prepend and append work properly
-{% endcomment %}
 {% if field.field.widget.bootstrap %}
     {% with bootstrap as field.field.widget.bootstrap %}
-        {% with prepend=prepend|default:field.field.widget.bootstrap.prepend|default:"" append=append|default:field.field.widget.bootstrap.append|default:"" %}
-            {% if prepend  %}
-                {% if append %}
-                    <div class="input-prepend input-append">
-                        <span class="add-on">{{ prepend }}</span>{{ field }}<span class="add-on">{{ append }}</span>
-                    </div>
-                {% else %}
-                    <div class="input-prepend">
-                        <span class="add-on">{{ prepend }}</span>{{ field }}
-                    </div>
-                {% endif %}
-            {% else %}
-                {% if append %}
-                    <div class="input-append">
-                        {{ field }}<span class="add-on">{{ append }}</span>
-                    </div>
-                {% else %}
-                    {{ field }}
-                {% endif %}
-            {% endif %}
+        {% with prepend=prepend|default:bootstrap.prepend|default:"" append=append|default:bootstrap.append|default:"" %}
+            {% include "bootstrap_toolkit/field_prepend_append.html" %}
         {% endwith %}
     {% endwith %}
 {% else %}
-    {{ field }}
+    {% if prepend or append %}
+        {% include "bootstrap_toolkit/field_prepend_append.html" %}
+    {% else %}
+        {{ field }}
+    {% endif %}
 {% endif %}

--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_prepend_append.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_prepend_append.html
@@ -1,0 +1,19 @@
+{% if prepend %}
+    {% if append %}
+        <div class="input-prepend input-append">
+            <span class="add-on">{{ prepend }}</span>{{ field }}<span class="add-on">{{ append }}</span>
+        </div>
+    {% else %}
+        <div class="input-prepend">
+            <span class="add-on">{{ prepend }}</span>{{ field }}
+        </div>
+    {% endif %}
+{% else %}
+    {% if append %}
+        <div class="input-append">
+            {{ field }}<span class="add-on">{{ append }}</span>
+        </div>
+    {% else %}
+        {{ field }}
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
The "bootstrap" dict check in template has some issue.

```
{% if field.field.widget.bootstrap %}
```

The above code was added to support BootstrapDateInput. However, it removed the function to use prepend / append on regular TextInput field because such field doesn't have the "bootstrap" attribute.

For example, the below code in your sample project won't work:

```
{% for field in form %}
    {% if field.name == 'disabled' %}
        {% include "bootstrap_toolkit/field.html" with append='$' %}
    {% else %}
        {% if field.name != 'color' %}
            {% include "bootstrap_toolkit/field.html" %}
        {% endif %}
    {% endif %}
{% endfor %}
```

Now this issue has been fixed by adding extra "prepend" and "append" check.

Also I simplified the code a little bit. Thanks.
