### PR TITLE
Removed redundant logic. Simplified code.

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_default.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_default.html
@@ -1,13 +1,7 @@
 {% if field.field.widget.bootstrap %}
     {% with bootstrap=field.field.widget.bootstrap %}
-        {% with prepend=prepend|default:bootstrap.prepend|default:"" append=append|default:bootstrap.append|default:"" %}
-            {% include "bootstrap_toolkit/field_prepend_append.html" %}
-        {% endwith %}
+        {% include "bootstrap_toolkit/field_prepend_append.html" with prepend=prepend|default:bootstrap.prepend|default:"" append=append|default:bootstrap.append|default:"" %}
     {% endwith %}
 {% else %}
-    {% if prepend or append %}
-        {% include "bootstrap_toolkit/field_prepend_append.html" %}
-    {% else %}
-        {{ field }}
-    {% endif %}
+    {% include "bootstrap_toolkit/field_prepend_append.html" %}
 {% endif %}


### PR DESCRIPTION
The field_prepend_append.html already has logic for regular TextInput without anything (output standard {{ field }}), so we do not need an extra check for prepend / append now.
