### PR TITLE
'{% include "..." with inline=True %}' does not what it's supposed to do

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_help.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_help.html
@@ -1,6 +1,6 @@
 {% if field.help_text %}
     {% autoescape off %}
-        {% if inline %}
+        {% if inline == 'true' %}
             <span class="help-inline">{{ field.help_text }}</span>
         {% else %}
             <p class="help-block">{{ field.help_text }}</p>

--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_inline.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_inline.html
@@ -1,21 +1,21 @@
 {% if input_type == "checkbox" %}
     {% include "bootstrap_toolkit/field_checkbox.html" %}
-    {% include "bootstrap_toolkit/field_help.html" with inline=True %}
+    {% include "bootstrap_toolkit/field_help.html" with inline='true' %}
 {% else %}
     {% if input_type == "multicheckbox" %}
         {% include "bootstrap_toolkit/field_choices.html" with type="checkbox" %}
-        {% include "bootstrap_toolkit/field_help.html" with inline=False %}
+        {% include "bootstrap_toolkit/field_help.html" with inline='false' %}
     {% else %}
         {% if field.label %}
             <label{% if field.auto_id %} for="{{ field.auto_id }}"{% endif %}>{{ field.label }}</label>
         {% endif %}
         {% if input_type == "radioset" %}
             {% include "bootstrap_toolkit/field_choices.html" with type="radio" %}
-            {% include "bootstrap_toolkit/field_help.html" with inline=False %}
+            {% include "bootstrap_toolkit/field_help.html" with inline='false' %}
         {% else %}
-            {% include "bootstrap_toolkit/field_default.html" with inline=True%}
-            {% include "bootstrap_toolkit/field_help.html" with inline=True %}
+            {% include "bootstrap_toolkit/field_default.html" with inline='true'%}
+            {% include "bootstrap_toolkit/field_help.html" with inline='true' %}
         {% endif %}
     {% endif %}
 {% endif %}
-{% include "bootstrap_toolkit/field_errors.html" with inline=False %}
+{% include "bootstrap_toolkit/field_errors.html" with inline='false' %}


### PR DESCRIPTION
While this fix changes the code to work as you would expect it seems to break the demo project "inline" demo.
