### PR TITLE
Define media as a dynamic property on BootstrapDateInput

### DIFF
--- a/bootstrap_toolkit/widgets.py
+++ b/bootstrap_toolkit/widgets.py
@@ -77,7 +77,8 @@ class BootstrapDateInput(forms.DateInput):
         'prepend': None,
     }
 
-    class Media:
+    @property
+    def media(self):
         js = (
             settings.STATIC_URL + 'datepicker/js/bootstrap-datepicker.js',
         )
@@ -96,6 +97,7 @@ class BootstrapDateInput(forms.DateInput):
                 settings.STATIC_URL + 'datepicker/css/datepicker.css',
             )
         }
+        return forms.Media(css=css, js=js)
 
     def render(self, name, value, attrs=None):
         if attrs is None:


### PR DESCRIPTION
Fixes an issue with BootstrapDateInput where the language-specific JS media does not change, although the languages for each response vary.

The list of js media depends on the current language, which may change between requests, so the media list must be recomputed for every request.
