### PR TITLE
Changed the default bootstrap URL to a CDN

### DIFF
--- a/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
+++ b/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
@@ -14,7 +14,7 @@ from django.utils.html import escape
 
 
 BOOTSTRAP_BASE_URL = getattr(settings, 'BOOTSTRAP_BASE_URL',
-                             'http://twitter.github.io/bootstrap/assets/'
+                             '//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.1/'
 )
 
 BOOTSTRAP_JS_BASE_URL = getattr(settings, 'BOOTSTRAP_JS_BASE_URL',


### PR DESCRIPTION
Using the bootstrap URL on github is not optimal, as for this type of content, it is much better to use a proper CDN that is optimised for low latency and speed globally. Another benefit of using the CloudFlare CDN is that the protocol is not included. This means that the bootstrap request will match the global one, eg: http with http or https with https.
