### PR TITLE
added: class based views + small inline fix

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/field_inline.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/field_inline.html
@@ -1,3 +1,4 @@
+<span class="control-group{% if field.errors %} error{% endif %}{% if field.field.required %} required{% endif %}">
 {% if input_type == "checkbox" %}
     {% include "bootstrap_toolkit/field_checkbox.html" %}
     {% include "bootstrap_toolkit/field_help.html" with display="inline" %}
@@ -7,7 +8,7 @@
         {% include "bootstrap_toolkit/field_help.html" with display="block" %}
     {% else %}
         {% if field.label %}
-            <label{% if field.auto_id %} for="{{ field.auto_id }}"{% endif %}>{{ field.label }}</label>
+            <label class="control-label"{% if field.auto_id %} for="{{ field.auto_id }}"{% endif %}>{{ field.label }}</label>
         {% endif %}
         {% if input_type == "radioset" %}
             {% include "bootstrap_toolkit/field_choices.html" with type="radio" %}
@@ -18,4 +19,5 @@
         {% endif %}
     {% endif %}
 {% endif %}
-{% include "bootstrap_toolkit/field_errors.html" with display="block" %}
+{% include "bootstrap_toolkit/field_errors.html" with display="inline" %}
+</span>

--- a/demo_project/demo_app/forms.py
+++ b/demo_project/demo_app/forms.py
@@ -21,6 +21,7 @@ class TestForm(forms.Form):
     )
     disabled = forms.CharField(
         max_length=100,
+        required=False,
         help_text=u'I am disabled',
         widget=forms.TextInput(attrs={
             'disabled': 'disabled',
@@ -62,7 +63,7 @@ class TestForm(forms.Form):
         help_text=u'And can be inline',
     )
     color = forms.ChoiceField(
-        widget=forms.RadioSelect(attrs = {'data-demo-attr': 'bazinga' }),
+        widget=forms.RadioSelect(attrs={'data-demo-attr': 'bazinga'}),
         choices=(
             ("#f00", "red"),
             ("#0f0", "green"),
@@ -78,7 +79,8 @@ class TestForm(forms.Form):
 
     def clean(self):
         cleaned_data = super(TestForm, self).clean()
-        raise forms.ValidationError("This error was added to show the non field errors styling.")
+        if not self.is_valid():
+            raise forms.ValidationError("This error was added to show the non field errors styling.")
         return cleaned_data
 
 

--- a/demo_project/demo_app/templates/base.html
+++ b/demo_project/demo_app/templates/base.html
@@ -29,20 +29,20 @@
             <a class="brand" href="/">django-bootstrap-toolkit</a>
             <ul class="nav">
                 <li><a href="{% url 'home' %}" class="">Home</a></li>
-                <li><a href="{% url 'demo_app.views.demo_form' %}">Form</a></li>
+                <li><a href="{% url 'cbv_df' %}">Form</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Forms<b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a class="nav" href="{% url 'demo_app.views.demo_form' %}?layout=vertical">Vertical</a></li>
-                        <li><a href="{% url 'demo_app.views.demo_form' %}?layout=horizontal">Horizontal</a></li>
-                        <li><a href="{% url 'demo_app.views.demo_form_inline' %}?layout=inline">Inline</a></li>
-                        <li><a href="{% url 'demo_app.views.demo_form_inline' %}?layout=search">Search</a></li>
-                        <li><a href="{% url 'demo_app.views.demo_form_with_template' %}?layout=horizontal">Using template</a></li>
+                        <li><a class="nav" href="{% url 'cbv_df' %}?layout=vertical">Vertical</a></li>
+                        <li><a href="{% url 'cbv_df' %}?layout=horizontal">Horizontal</a></li>
+                        <li><a href="{% url 'cbv_dfil' %}?layout=inline">Inline</a></li>
+                        <li><a href="{% url 'cbv_dfil' %}?layout=search">Search</a></li>
+                        <li><a href="{% url 'cbv_tf' %}?layout=horizontal">Using template</a></li>
                     </ul>
                 </li>
-                <li><a href="{% url 'formset' %}">Formset</a></li>
-                <li><a href="{% url 'tabs' %}">Tabs &amp; Pills</a></li>
-                <li><a href="{% url 'pagination' %}">Pagination</a></li>
+                <li><a href="{% url 'cbv_fs' %}">Formset</a></li>
+                <li><a href="{% url 'cbv_dt' %}">Tabs &amp; Pills</a></li>
+                <li><a href="{% url 'cbv_dp' %}">Pagination</a></li>
                 <li><a href="{% url 'contact' %}">Contact</a></li>
             </ul>
         </div>

--- a/demo_project/demo_app/templates/formset.html
+++ b/demo_project/demo_app/templates/formset.html
@@ -12,7 +12,7 @@
 
     <p>&nbsp;</p>
 
-    <form class="form-inline" action="" method="post">
+    <form class="form-{{ layout }}" action="" method="post">
         {% csrf_token %}
 
         {% bootstrap_formset formset=formset layout=layout %}

--- a/demo_project/demo_app/views.py
+++ b/demo_project/demo_app/views.py
@@ -8,6 +8,28 @@ from bootstrap_toolkit.widgets import BootstrapUneditableInput
 
 from .forms import TestForm, TestModelForm, TestInlineForm, WidgetsForm, FormSetInlineForm
 
+from django.views.generic import FormView
+from django.views.generic import TemplateView
+
+
+class TemplateFormView(FormView):
+    template_name = 'form_using_template.html'
+    form_class = TestForm
+    success_url = '.'
+
+    def form_valid(self, form):
+        # do something with data here
+        return super(TemplateFormView, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(TemplateFormView, self).get_context_data(**kwargs)
+        context['layout'] = self.request.GET.get('layout', 'vertical')
+        if self.request.method == 'POST':
+            context['form'] = TestForm(self.request.POST)
+        elif self.request.method == 'GET':
+            context['form'] = TestForm()
+        return context
+
 
 def demo_form_with_template(request):
     layout = request.GET.get('layout')
@@ -23,6 +45,28 @@ def demo_form_with_template(request):
         'form': form,
         'layout': layout,
     }))
+
+
+class DemoFormView(FormView):
+    template_name = 'form.html'
+    form_class = TestForm
+    success_url = '.'
+
+    def form_valid(self, form):
+        # do something with data here
+        messages.success(self.request, 'I am a success message.')
+        return super(DemoFormView, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(DemoFormView, self).get_context_data(**kwargs)
+        context['layout'] = self.request.GET.get('layout', 'vertical')
+        if self.request.method == 'POST':
+            context['form'] = TestForm(self.request.POST)
+        elif self.request.method == 'GET':
+            context['form'] = TestForm()
+        #context['form'].fields['title'].widget = BootstrapUneditableInput()
+        return context
+
 
 def demo_form(request):
     messages.success(request, 'I am a success message.')
@@ -40,6 +84,29 @@ def demo_form(request):
         'layout': layout,
     }))
 
+
+class DemoFormInlineView(FormView):
+    template_name = 'form_inline.html'
+    form_class = TestForm
+    success_url = '.'
+
+    def form_valid(self, form):
+        # do something with data
+        messages.success(self.request, 'Search results?')
+        return super(DemoFormInlineView, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(DemoFormInlineView, self).get_context_data(**kwargs)
+        context['layout'] = self.request.GET.get('layout', 'inline')
+        if context['layout'] != 'inline':
+            context['layout'] = 'search'
+        if self.request.method == 'POST':
+            context['form'] = TestInlineForm(self.request.POST)
+        elif self.request.method == 'GET':
+            context['form'] = TestInlineForm()
+        return context
+
+
 def demo_form_inline(request):
     layout = request.GET.get('layout', '')
     if layout != 'search':
@@ -49,6 +116,28 @@ def demo_form_inline(request):
         'form': form,
         'layout': layout,
     }))
+
+
+class DemoFormSetView(FormView):
+    template_name = 'formset.html'
+    form_class = FormSetInlineForm
+    success_url = '.'
+
+    def form_valid(self, form):
+        # do something with data here
+        messages.success(self.request, 'This is a success message.')
+        return super(DemoFormSetView, self).form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super(DemoFormSetView, self).get_context_data(**kwargs)
+        context['layout'] = self.request.GET.get('layout', 'inline')
+        DemoFormSet = formset_factory(FormSetInlineForm)
+        if self.request.method == 'POST':
+            context['formset'] = DemoFormSet(self.request.POST,
+                                             self.request.FILES)
+        elif self.request.method == 'GET':
+            context['formset'] = DemoFormSet()
+        return context
 
 
 def demo_formset(request):
@@ -67,24 +156,64 @@ def demo_formset(request):
     }))
 
 
+class DemoTabsView(TemplateView):
+    template_name = 'tabs.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(DemoTabsView, self).get_context_data(**kwargs)
+        context['layout'] = self.request.GET.get('layout', 'tabs')
+        context['tabs'] = [
+            {
+                'link': "#",
+                'title': 'Tab 1',
+            },
+            {
+                'link': "#",
+                'title': 'Tab 2',
+            }
+        ]
+        return context
+
+
 def demo_tabs(request):
     layout = request.GET.get('layout')
     if not layout:
         layout = 'tabs'
     tabs = [
         {
-            'link': "#",
-            'title': 'Tab 1',
-            },
+         'link': "#",
+         'title': 'Tab 1',
+        },
         {
-            'link': "#",
-            'title': 'Tab 2',
-            }
+         'link': "#",
+         'title': 'Tab 2',
+        }
     ]
     return render_to_response('tabs.html', RequestContext(request, {
         'tabs': tabs,
         'layout': layout,
         }))
+
+
+class DemoPaginationView(TemplateView):
+    template_name = 'pagination.html'
+
+    def get_context_data(self, **kwargs):
+        context = super(DemoPaginationView, self).get_context_data(**kwargs)
+        lines = []
+        for i in range(10000):
+            lines.append(u'Line %s' % (i + 1))
+        paginator = Paginator(lines, 10)
+        page = self.request.GET.get('page')
+        try:
+            context['lines'] = paginator.page(page)
+        except PageNotAnInteger:
+            # If page is not an integer, deliver first page.
+            context['lines'] = paginator.page(1)
+        except EmptyPage:
+            # If page is out of range (e.g. 9999), deliver last page of results.
+            context['lines'] = paginator.page(paginator.num_pages)
+        return context
 
 
 def demo_pagination(request):

--- a/demo_project/urls.py
+++ b/demo_project/urls.py
@@ -4,6 +4,12 @@ from django.conf.urls import patterns, url
 # from django.contrib import admin
 # admin.autodiscover()
 from django.views.generic import TemplateView
+from demo_app.views import TemplateFormView
+from demo_app.views import DemoFormView
+from demo_app.views import DemoFormInlineView
+from demo_app.views import DemoFormSetView
+from demo_app.views import DemoTabsView
+from demo_app.views import DemoPaginationView
 
 urlpatterns = patterns('',
     # Examples:
@@ -25,4 +31,11 @@ urlpatterns = patterns('',
     url(r'^tabs$', 'demo_app.views.demo_tabs', {}, "tabs"),
     url(r'^pagination$', 'demo_app.views.demo_pagination', {}, "pagination"),
     url(r'^widgets$', 'demo_app.views.demo_widgets', {}, "widgets"),
+
+    url(r'^cbv_tf$', TemplateFormView.as_view(), name='cbv_tf'),
+    url(r'^cbv_df$', DemoFormView.as_view(), name='cbv_df'),
+    url(r'^cbv_dfil$', DemoFormInlineView.as_view(), name='cbv_dfil'),
+    url(r'^cbv_fs$', DemoFormSetView.as_view(), {}, name='cbv_fs'),
+    url(r'^cbv_dt$', DemoTabsView.as_view(), {}, name='cbv_dt'),
+    url(r'^cbv_dp$', DemoPaginationView.as_view(), {}, name='cbv_dp'),
 )


### PR DESCRIPTION
when rendering forms as inline layout, most notably the formset, form fields were not getting control-group class assigned. There was also a small bug on with field errors getting rendered as display="block" instead of display="inline", for inline layouts, which is also fixed.

Along with that, I substituted the old views for class based views on the demo_app, but left the original views there, for comparison.
