### PR TITLE
Updating init_datepicker.js to allow init of widgets on inline forms

### DIFF
--- a/bootstrap_toolkit/static/bootstrap_toolkit/js/init_datepicker.js
+++ b/bootstrap_toolkit/static/bootstrap_toolkit/js/init_datepicker.js
@@ -1,5 +1,5 @@
 (function($){
-    $(function() {
-        $('input[data-bootstrap-widget=datepicker]').datepicker();
-    })
+    $(document).on('focus.django-bootstrap-toolkit.data-api click.django-bootstrap-toolkit.data-api', 'input[data-bootstrap-widget=datepicker][data-provide!="datepicker"]', function (e) {
+        $(e.target).datepicker("show");
+    });
 })(jQuery);


### PR DESCRIPTION
While using BootstrapDateInput on a form used on a [StackedInline](https://docs.djangoproject.com/en/1.5/ref/contrib/admin/#django.contrib.admin.StackedInline) admin class, I noticed that the picker wouldn't show up on click for elements that were added after page load.

Instead of initializing all datepickers that exist on document ready, this change makes it so that a datepicker is initialized on focus or click for inputs that are not already initialized.
