### PR TITLE
Allow specifying extra CSS classes for pagination

### DIFF
--- a/bootstrap_toolkit/templates/bootstrap_toolkit/pagination.html
+++ b/bootstrap_toolkit/templates/bootstrap_toolkit/pagination.html
@@ -1,6 +1,6 @@
 {% with bootstrap_pagination_url=bootstrap_pagination_url|default:"?" %}
 
-    <div class="pagination">
+    <div class="pagination {{ css_class_extra }}">
         <ul>
 
             <li class="prev{% if current_page == 1 %} disabled{% endif %}">

--- a/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
+++ b/bootstrap_toolkit/templatetags/bootstrap_toolkit.py
@@ -293,7 +293,7 @@ def bootstrap_pagination(page, **kwargs):
     return get_pagination_context(**pagination_kwargs)
 
 
-def get_pagination_context(page, pages_to_show=11, url=None, extra=None):
+def get_pagination_context(page, pages_to_show=11, url=None, css_class_extra="", extra=None):
     """
     Generate Bootstrap pagination context from a page object
     """
@@ -362,4 +362,5 @@ def get_pagination_context(page, pages_to_show=11, url=None, extra=None):
         'pages_shown': pages_shown,
         'pages_back': pages_back,
         'pages_forward': pages_forward,
+        'css_class_extra': css_class_extra,
     }


### PR DESCRIPTION
Bootstrap has lots of layout features for pagination that can be used by setting classes to the pagination holder div, such as making the pagination strip bigger, centered, and so on. With this change those classes can be specified as bootstrap_pagination template tag parameters.
